### PR TITLE
Delete CNAME file - Removing custom domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-docs.baserock.ai
+


### PR DESCRIPTION
Remove CNAME for docs.baserock.ai